### PR TITLE
Use negative lookahead/lookbehind around match terms

### DIFF
--- a/src/algos/keyboards.ts
+++ b/src/algos/keyboards.ts
@@ -160,9 +160,9 @@ export class manager extends AlgoManager {
   ]
 
   public re = new RegExp(
-    `^(?!.*\\b((swiss|french|italian|austrian) alps|mountain(s)?|dice)\\b).*\\b(${this.matchTerms.join(
+    `^(?!.*\\b((swiss|french|italian|austrian) alps|mountain(s)?|dice)\\b).*(?<!\\w)(${this.matchTerms.join(
       '|',
-    )})(es|s)?\\b.*$`,
+    )})(es|s)?(?!\\w).*$`,
     'ims',
   )
 


### PR DESCRIPTION
Turns out putting `\b` around the match terms won't match `⌨️` because an emoji isn't a word. [Using a negative lookbehind & lookahead](https://stackoverflow.com/questions/64431334/how-can-i-use-b-boundary-around-special-characters) for word characters around the match terms instead solves that.