### PR TITLE
Update github cli feature (old path no longer works)

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -7,7 +7,7 @@
 
 	// Features to add to the dev container. More info: https://containers.dev/features.
 	"features": {
-		"ghcr.io/devcontainers-contrib/features/gh-cli:1": {}
+		"ghcr.io/devcontainers/features/github-cli:1": {}
 	},
 
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.


### PR DESCRIPTION
```
* [httpOci] 403: Credentials for 'ghcr.io' may be expired. Attempting request anonymously.
[2025-06-30T14:38:32.202Z] {"errors":[{"code":"DENIED","message":"requested access to the resource is denied"}]}
.
[2025-06-30T14:38:32.337Z] [httpOci] 403: Failed to fetch bearer token for 'ghcr.io': {"errors":[{"code":"DENIED","message":"requested access to the resource is denied"}]}
[2025-06-30T14:38:32.337Z] 
```