### PR TITLE
fixes issue with external list (#154)

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,30 +4,26 @@
 	"name": "Node.js & TypeScript",
 	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
 	"image": "mcr.microsoft.com/devcontainers/typescript-node:20",
-
 	// Features to add to the dev container. More info: https://containers.dev/features.
 	"features": {
-		"ghcr.io/devcontainers-contrib/features/gh-cli:1": {}
+		"ghcr.io/devcontainers/features/github-cli:1": {}
 	},
-
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	"forwardPorts": [
 		//3000
 	],
-
 	// Use 'postCreateCommand' to run commands after the container is created.
 	"postCreateCommand": "yarn install",
 	"customizations": {
 		"vscode": {
 			"extensions": [
-				"esbenp.prettier-vscode"
+				"esbenp.prettier-vscode",
+				"kodu-ai.claude-dev-experimental"
 			]
 		}
 	}
-
 	// Configure tool-specific properties.
 	// "customizations": {},
-
 	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
 	// "remoteUser": "root"
 }

--- a/src/methods/feed-generation.ts
+++ b/src/methods/feed-generation.ts
@@ -54,9 +54,24 @@ export default function (server: Server, ctx: AppContext) {
 
     if (body === undefined) {
       body = await algo(ctx, params)
-      algoCache.set(cacheKey, { date: Date.now(), output: body })
+      // Only add to cache if body is defined
+      if (body) {
+        algoCache.set(cacheKey, { date: Date.now(), output: body })
+      }
     }
-    if (body.feed.length < params.limit) body.cursor = undefined
+
+    // Ensure body is defined before accessing its properties
+    if (body && body.feed.length < params.limit) {
+      body.cursor = undefined
+    }
+
+    // Ensure we never return undefined for body
+    if (!body) {
+      throw new InvalidRequestError(
+        'Failed to generate feed',
+        'FeedGenerationError',
+      )
+    }
 
     return {
       encoding: 'application/json',


### PR DESCRIPTION
In `src/methods/feed-generation.ts`, the body variable was declared as `AlgoOutput | undefined`, but it was being accessed without checking if it was undefined. This caused TypeScript errors when the external list algorithm was removed.

I made the following changes to fix the issues:

a. Added a null check before accessing body.feed.length:

```typescript
    // Ensure body is defined before accessing its properties
    if (body && body.feed.length < params.limit) {
      body.cursor = undefined
    }
```

b. Added a check to ensure body is never undefined when returned:
```typescript
    // Ensure we never return undefined for body
    if (!body) {
      throw new InvalidRequestError(
        'Failed to generate feed',
        'FeedGenerationError',
      )
    }
```

c. Added a check to ensure body is not undefined before adding it to the cache:
```typescript
    if (body === undefined) {
      body = await algo(ctx, params)
      // Only add to cache if body is defined
      if (body) {
        algoCache.set(cacheKey, { date: Date.now(), output: body })
      }
    }
```